### PR TITLE
Add bindings for file detectors

### DIFF
--- a/docs/Selenium.md
+++ b/docs/Selenium.md
@@ -106,6 +106,12 @@ findChildren :: forall e f. (Unfoldable f) => Element -> Locator -> Aff (seleniu
 
 Same as `findElements` but starts searching from custom element
 
+#### `setFileDetector`
+
+``` purescript
+setFileDetector :: forall e. Driver -> FileDetector -> Eff (selenium :: SELENIUM | e) Unit
+```
+
 #### `navigateBack`
 
 ``` purescript

--- a/docs/Selenium/Remote.md
+++ b/docs/Selenium/Remote.md
@@ -1,0 +1,9 @@
+## Module Selenium.Remote
+
+#### `fileDetector`
+
+``` purescript
+fileDetector :: forall e. Eff (selenium :: SELENIUM | e) FileDetector
+```
+
+

--- a/docs/Selenium/Types.md
+++ b/docs/Selenium/Types.md
@@ -108,6 +108,12 @@ data ScrollBehaviour :: *
 data Capabilities :: *
 ```
 
+#### `FileDetector`
+
+``` purescript
+data FileDetector :: *
+```
+
 #### `Location`
 
 ``` purescript

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ var exampleForeigns = [
 gulp.task("make", function() {
     return purescript.psc({
         src: sources,
-        ffi: foreigns 
+        ffi: foreigns
     });
 });
 
@@ -45,6 +45,7 @@ gulp.task("docs", function() {
             "Selenium.Builder": "docs/Selenium/Builder.md",
             "Selenium.Key": "docs/Selenium/Key.md",
             "Selenium.MouseButton": "docs/Selenium/MouseButton.md",
+            "Selenium.Remote": "docs/Selenium/Remote.md",
             "Selenium.ScrollBehaviuor": "docs/Selenium/ScrollBehaviuor.md",
             "Selenium.Types": "docs/Selenium/Types.md"
         }

--- a/src/Selenium.js
+++ b/src/Selenium.js
@@ -11,6 +11,14 @@ exports.get = function(driver) {
     };
 };
 
+exports.setFileDetector = function(driver) {
+    return function(detector) {
+        return function () {
+          driver.setFileDetector(detector);
+        };
+    };
+};
+
 exports.wait = function(check) {
     return function(timeout) {
         return function(driver) {

--- a/src/Selenium.purs
+++ b/src/Selenium.purs
@@ -27,6 +27,7 @@ module Selenium
        , isEnabled
        , getInnerHtml
        , clearEl
+       , setFileDetector
        ) where
 
 import Prelude
@@ -44,8 +45,8 @@ import DOM (DOM())
 
 -- | Go to url
 foreign import get :: forall e. Driver -> String -> Aff (selenium :: SELENIUM|e) Unit
--- | Wait until first argument returns 'true'. If it returns false an error will be raised 
-foreign import wait :: forall e. Aff (selenium :: SELENIUM|e) Boolean -> 
+-- | Wait until first argument returns 'true'. If it returns false an error will be raised
+foreign import wait :: forall e. Aff (selenium :: SELENIUM|e) Boolean ->
                                  Int -> Driver ->
                                  Aff (selenium :: SELENIUM|e) Unit
 -- | Finalizer
@@ -58,10 +59,10 @@ foreign import byCss :: forall e. String -> Aff (selenium :: SELENIUM|e) Locator
 foreign import byId :: forall e. String -> Aff (selenium :: SELENIUM|e) Locator
 foreign import byName :: forall e. String -> Aff (selenium :: SELENIUM|e) Locator
 foreign import byXPath :: forall e. String -> Aff (selenium :: SELENIUM|e) Locator
--- | Build locator from asynchronous function returning element. 
+-- | Build locator from asynchronous function returning element.
 -- | I.e. this locator will find first visible element with `.common-element` class
--- | ```purescript 
--- | affLocator \el -> do 
+-- | ```purescript
+-- | affLocator \el -> do
 -- |   commonElements <- byCss ".common-element" >>= findElements el
 -- |   flagedElements <- traverse (\el -> Tuple el <$> isVisible el) commonElements
 -- |   maybe err pure $ foldl foldFn Nothing flagedElements
@@ -73,9 +74,9 @@ foreign import byXPath :: forall e. String -> Aff (selenium :: SELENIUM|e) Locat
 foreign import affLocator :: forall e. (Element -> Aff (selenium :: SELENIUM|e) Element) -> Aff (selenium :: SELENIUM|e) Locator
 
 
-foreign import _findElement :: forall e a. Maybe a -> (a -> Maybe a) -> 
+foreign import _findElement :: forall e a. Maybe a -> (a -> Maybe a) ->
                                Driver -> Locator -> Aff (selenium :: SELENIUM|e) (Maybe Element)
-foreign import _findChild :: forall e a. Maybe a -> (a -> Maybe a) -> 
+foreign import _findChild :: forall e a. Maybe a -> (a -> Maybe a) ->
                              Element -> Locator -> Aff (selenium :: SELENIUM|e) (Maybe Element)
 foreign import _findElements :: forall e. Driver -> Locator -> Aff (selenium :: SELENIUM|e) (Array Element)
 foreign import _findChildren :: forall e. Element -> Locator -> Aff (selenium :: SELENIUM|e) (Array Element)
@@ -83,22 +84,23 @@ foreign import _findChildren :: forall e. Element -> Locator -> Aff (selenium ::
 -- | Tries to find an element starting from `document` will return `Nothing` if there
 -- | is no element can be found by locator
 findElement :: forall e. Driver -> Locator -> Aff (selenium :: SELENIUM|e) (Maybe Element)
-findElement = _findElement Nothing Just 
+findElement = _findElement Nothing Just
 
 -- | Finds elements by locator from `document`
-findElements :: forall e f. (Unfoldable f) => Driver -> Locator -> Aff (selenium :: SELENIUM|e) (f Element) 
-findElements driver locator = 
+findElements :: forall e f. (Unfoldable f) => Driver -> Locator -> Aff (selenium :: SELENIUM|e) (f Element)
+findElements driver locator =
   unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> uncons xs) <$> (_findElements driver locator)
 
--- | Same as `findElement` but starts searching from custom element 
+-- | Same as `findElement` but starts searching from custom element
 findChild :: forall e. Element -> Locator -> Aff (selenium :: SELENIUM|e) (Maybe Element)
 findChild = _findChild Nothing Just
 
 -- | Same as `findElements` but starts searching from custom element
-findChildren :: forall e f. (Unfoldable f) => Element -> Locator -> Aff (selenium ::SELENIUM|e) (f Element) 
-findChildren el locator = 
+findChildren :: forall e f. (Unfoldable f) => Element -> Locator -> Aff (selenium ::SELENIUM|e) (f Element)
+findChildren el locator =
   unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> uncons xs) <$> (_findChildren el locator)
 
+foreign import setFileDetector :: forall e. Driver -> FileDetector -> Eff (selenium :: SELENIUM|e) Unit
 
 foreign import navigateBack :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
 foreign import navigateForward :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
@@ -116,14 +118,11 @@ foreign import getAttribute :: forall e. Element -> String -> Aff (selenium :: S
 foreign import isDisplayed :: forall e. Element -> Aff (selenium :: SELENIUM|e) Boolean
 foreign import isEnabled :: forall e. Element -> Aff (selenium :: SELENIUM|e) Boolean
 foreign import getInnerHtml :: forall e. Element -> Aff (selenium :: SELENIUM|e) String
--- | Clear `value` of element, if it has no value will do nothing. 
--- | If `value` is weakly referenced by `virtual-dom` (`purescript-halogen`) 
--- | will not work -- to clear such inputs one should use direct signal from 
+-- | Clear `value` of element, if it has no value will do nothing.
+-- | If `value` is weakly referenced by `virtual-dom` (`purescript-halogen`)
+-- | will not work -- to clear such inputs one should use direct signal from
 -- | `Selenium.ActionSequence`
 foreign import clearEl :: forall e. Element -> Aff (selenium :: SELENIUM|e) Unit
-
-          
-
 
 
 

--- a/src/Selenium/Remote.js
+++ b/src/Selenium/Remote.js
@@ -1,0 +1,7 @@
+// module Selenium.Remote
+
+var remote = require('selenium-webdriver/remote');
+
+exports.fileDetector = function () {
+  return new remote.FileDetector();
+};

--- a/src/Selenium/Remote.purs
+++ b/src/Selenium/Remote.purs
@@ -1,0 +1,6 @@
+module Selenium.Remote where
+
+import Control.Monad.Eff (Eff())
+import Selenium.Types
+
+foreign import fileDetector :: forall e. Eff (selenium :: SELENIUM | e) FileDetector

--- a/src/Selenium/Types.purs
+++ b/src/Selenium/Types.purs
@@ -1,4 +1,4 @@
-module Selenium.Types where 
+module Selenium.Types where
 
 foreign import data Builder :: *
 foreign import data SELENIUM :: !
@@ -18,6 +18,7 @@ foreign import data ProxyConfig :: *
 foreign import data SafariOptions :: *
 foreign import data ScrollBehaviour :: *
 foreign import data Capabilities :: *
+foreign import data FileDetector :: *
 
 
 type Location =


### PR DESCRIPTION
After much wrangling of the Selenium SDK, I've got file detectors working properly, I think. (Note to self—if I ever write a JavaScript library, I should try to avoid having my code rewrite itself over time.)

This changeset also includes the removal of trailing whitespace from `Selenium.purs`; I'm happy to rebase that out if the reviewer prefers. (But it might be a good idea for folks to get their editors to perform this automatically!)