### PR TITLE
Rename module Selenium.ScrollBehaviuor ⇒ Selenium.ScrollBehavior

### DIFF
--- a/docs/Selenium/ScrollBehaviour.md
+++ b/docs/Selenium/ScrollBehaviour.md
@@ -1,4 +1,4 @@
-## Module Selenium.ScrollBehaviuor
+## Module Selenium.ScrollBehaviour
 
 #### `top`
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task("docs", function() {
             "Selenium.Key": "docs/Selenium/Key.md",
             "Selenium.MouseButton": "docs/Selenium/MouseButton.md",
             "Selenium.Remote": "docs/Selenium/Remote.md",
-            "Selenium.ScrollBehaviuor": "docs/Selenium/ScrollBehaviuor.md",
+            "Selenium.ScrollBehaviour": "docs/Selenium/ScrollBehaviour.md",
             "Selenium.Types": "docs/Selenium/Types.md"
         }
     });

--- a/src/Selenium/ScrollBehaviour.js
+++ b/src/Selenium/ScrollBehaviour.js
@@ -1,4 +1,4 @@
-// module Selenium.ScrollBehaviuor
+// module Selenium.ScrollBehaviour
 
 exports.top = 0;
 exports.bottom = 1;

--- a/src/Selenium/ScrollBehaviour.purs
+++ b/src/Selenium/ScrollBehaviour.purs
@@ -1,4 +1,4 @@
-module Selenium.ScrollBehaviuor where
+module Selenium.ScrollBehaviour where
 
 import Selenium.Types
 


### PR DESCRIPTION
Well, I do not have a preference between the British or the American spelling, but in correcting the misspelt version, I chose to match the filename (which was spelt in the British way). But if folks prefer me to change to to "Behavior", I'm of course fine with that as well.