### PR TITLE
combinators, spy-xhr, reader interface

### DIFF
--- a/docs/Selenium.md
+++ b/docs/Selenium.md
@@ -73,6 +73,18 @@ affLocator \el -> do
   foldFn a _ = a
 ```
 
+#### `findExact`
+
+``` purescript
+findExact :: forall e. Driver -> Locator -> Aff (selenium :: SELENIUM | e) Element
+```
+
+#### `childExact`
+
+``` purescript
+childExact :: forall e. Element -> Locator -> Aff (selenium :: SELENIUM | e) Element
+```
+
 #### `findElement`
 
 ``` purescript
@@ -109,7 +121,7 @@ Same as `findElements` but starts searching from custom element
 #### `setFileDetector`
 
 ``` purescript
-setFileDetector :: forall e. Driver -> FileDetector -> Eff (selenium :: SELENIUM | e) Unit
+setFileDetector :: forall e. Driver -> FileDetector -> Aff (selenium :: SELENIUM | e) Unit
 ```
 
 #### `navigateBack`
@@ -130,10 +142,10 @@ navigateForward :: forall e. Driver -> Aff (selenium :: SELENIUM | e) Unit
 refresh :: forall e. Driver -> Aff (selenium :: SELENIUM | e) Unit
 ```
 
-#### `to`
+#### `navigateTo`
 
 ``` purescript
-to :: forall e. String -> Driver -> Aff (selenium :: SELENIUM | e) Unit
+navigateTo :: forall e. String -> Driver -> Aff (selenium :: SELENIUM | e) Unit
 ```
 
 #### `getCurrentUrl`

--- a/docs/Selenium/Combinators.md
+++ b/docs/Selenium/Combinators.md
@@ -1,0 +1,88 @@
+## Module Selenium.Combinators
+
+#### `retry`
+
+``` purescript
+retry :: forall e o a. Int -> Selenium e o a -> Selenium e o a
+```
+
+Retry computation until it successed but not more then `n` times
+
+#### `tryFind`
+
+``` purescript
+tryFind :: forall e o. String -> Selenium e o Element
+```
+
+Tries to find element by string checks: css, xpath, id, name and classname
+
+#### `waitUntilJust`
+
+``` purescript
+waitUntilJust :: forall e o a. Selenium e o (Maybe a) -> Int -> Selenium e o a
+```
+
+#### `checker`
+
+``` purescript
+checker :: forall e o a. Selenium e o Boolean -> Selenium e o Boolean
+```
+
+#### `getElementByCss`
+
+``` purescript
+getElementByCss :: forall e o. String -> Selenium e o Element
+```
+
+#### `checkNotExistsByCss`
+
+``` purescript
+checkNotExistsByCss :: forall e o. String -> Selenium e o Unit
+```
+
+#### `contra`
+
+``` purescript
+contra :: forall e o a. Selenium e o a -> Selenium e o Unit
+```
+
+#### `waiter`
+
+``` purescript
+waiter :: forall e o a. Selenium e o a -> Int -> Selenium e o a
+```
+
+takes value and repeatedly tries to evaluate it for timeout of ms (second arg)
+if it evaluates w/o error returns its value
+else throws error 
+
+#### `waitExistentCss`
+
+``` purescript
+waitExistentCss :: forall e o. String -> Int -> Selenium e o Element
+```
+
+#### `waitNotExistentCss`
+
+``` purescript
+waitNotExistentCss :: forall e o. String -> Int -> Selenium e o Unit
+```
+
+#### `await`
+
+``` purescript
+await :: forall e o. Int -> Selenium e o Boolean -> Selenium e o Unit
+```
+
+Repeatedly tries to evaluate check (third arg) for timeout ms (first arg)
+finishes when check evaluates to true.
+If there is an error during check or it constantly returns `false`
+throws error with message (second arg)
+
+#### `awaitUrlChanged`
+
+``` purescript
+awaitUrlChanged :: forall e o. String -> Selenium e o Boolean
+```
+
+

--- a/docs/Selenium/Monad.md
+++ b/docs/Selenium/Monad.md
@@ -1,0 +1,297 @@
+## Module Selenium.Monad
+
+Most functions of `Selenium` use `Driver` as an argument
+This module supposed to make code a bit cleaner through
+putting `Driver` to `ReaderT`
+
+#### `Selenium`
+
+``` purescript
+type Selenium e o a = ReaderT { driver :: Driver | o } (Aff (console :: CONSOLE, selenium :: SELENIUM, dom :: DOM | e)) a
+```
+
+`Driver` is field of `ReaderT` context
+Usually selenium tests are run with tons of configs (i.e. xpath locators,
+timeouts) all those configs can be putted to `Selenium e o a`
+
+#### `getDriver`
+
+``` purescript
+getDriver :: forall e o. Selenium e o Driver
+```
+
+get driver from context
+
+#### `apathize`
+
+``` purescript
+apathize :: forall e o a. Selenium e o a -> Selenium e o Unit
+```
+
+#### `attempt`
+
+``` purescript
+attempt :: forall e o a. Selenium e o a -> Selenium e o (Either Error a)
+```
+
+#### `later`
+
+``` purescript
+later :: forall e o a. Int -> Selenium e o a -> Selenium e o a
+```
+
+#### `get`
+
+``` purescript
+get :: forall e o. String -> Selenium e o Unit
+```
+
+#### `wait`
+
+``` purescript
+wait :: forall e o. Selenium e o Boolean -> Int -> Selenium e o Unit
+```
+
+#### `byCss`
+
+``` purescript
+byCss :: forall e o. String -> Selenium e o Locator
+```
+
+#### `byXPath`
+
+``` purescript
+byXPath :: forall e o. String -> Selenium e o Locator
+```
+
+#### `byId`
+
+``` purescript
+byId :: forall e o. String -> Selenium e o Locator
+```
+
+#### `byName`
+
+``` purescript
+byName :: forall e o. String -> Selenium e o Locator
+```
+
+#### `byClassName`
+
+``` purescript
+byClassName :: forall e o. String -> Selenium e o Locator
+```
+
+#### `locator`
+
+``` purescript
+locator :: forall e o. (Element -> Selenium e o Element) -> Selenium e o Locator
+```
+
+get element by action returning an element
+```purescript
+locator \el -> do 
+  commonElements <- byCss ".common-element" >>= findElements el 
+  flaggedElements <- traverse (\el -> Tuple el <$> isVisible el) commonElements
+  maybe err pure $ foldl foldFn Nothing flaggedElements
+  where
+  err = throwError $ error "all common elements are not visible"
+  foldFn Nothing (Tuple el true) = Just el
+  foldFn a _ = a 
+```
+
+#### `findElement`
+
+``` purescript
+findElement :: forall e o. Locator -> Selenium e o (Maybe Element)
+```
+
+Tries to find element and return it wrapped in `Just` 
+
+#### `findElements`
+
+``` purescript
+findElements :: forall e o. Locator -> Selenium e o (List Element)
+```
+
+#### `findChild`
+
+``` purescript
+findChild :: forall e o. Element -> Locator -> Selenium e o (Maybe Element)
+```
+
+Tries to find child and return it wrapped in `Just`
+
+#### `findChildren`
+
+``` purescript
+findChildren :: forall e o. Element -> Locator -> Selenium e o (List Element)
+```
+
+#### `getInnerHtml`
+
+``` purescript
+getInnerHtml :: forall e o. Element -> Selenium e o String
+```
+
+#### `isDisplayed`
+
+``` purescript
+isDisplayed :: forall e o. Element -> Selenium e o Boolean
+```
+
+#### `isEnabled`
+
+``` purescript
+isEnabled :: forall e o. Element -> Selenium e o Boolean
+```
+
+#### `getCssValue`
+
+``` purescript
+getCssValue :: forall e o. Element -> String -> Selenium e o String
+```
+
+#### `getAttribute`
+
+``` purescript
+getAttribute :: forall e o. Element -> String -> Selenium e o String
+```
+
+#### `clearEl`
+
+``` purescript
+clearEl :: forall e o. Element -> Selenium e o Unit
+```
+
+#### `sendKeysEl`
+
+``` purescript
+sendKeysEl :: forall e o. String -> Element -> Selenium e o Unit
+```
+
+#### `script`
+
+``` purescript
+script :: forall e o. String -> Selenium e o Foreign
+```
+
+#### `getCurrentUrl`
+
+``` purescript
+getCurrentUrl :: forall e o. Selenium e o String
+```
+
+#### `navigateBack`
+
+``` purescript
+navigateBack :: forall e o. Selenium e o Unit
+```
+
+#### `navigateForward`
+
+``` purescript
+navigateForward :: forall e o. Selenium e o Unit
+```
+
+#### `navigateTo`
+
+``` purescript
+navigateTo :: forall e o. String -> Selenium e o Unit
+```
+
+#### `setFileDetector`
+
+``` purescript
+setFileDetector :: forall e o. FileDetector -> Selenium e o Unit
+```
+
+#### `getTitle`
+
+``` purescript
+getTitle :: forall e o. Selenium e o String
+```
+
+#### `sequence`
+
+``` purescript
+sequence :: forall e o. Sequence Unit -> Selenium e o Unit
+```
+
+Run sequence of actions 
+
+#### `actions`
+
+``` purescript
+actions :: forall e o. ({ driver :: Driver | o } -> Sequence Unit) -> Selenium e o Unit
+```
+
+Same as `sequence` but takes function of `ReaderT` as an argument
+
+#### `stop`
+
+``` purescript
+stop :: forall e o. Selenium e o Unit
+```
+
+Stop computations
+
+#### `refresh`
+
+``` purescript
+refresh :: forall e o. Selenium e o Unit
+```
+
+#### `quit`
+
+``` purescript
+quit :: forall e o. Selenium e o Unit
+```
+
+#### `takeScreenshot`
+
+``` purescript
+takeScreenshot :: forall e o. Selenium e o String
+```
+
+#### `findExact`
+
+``` purescript
+findExact :: forall e o. Locator -> Selenium e o Element
+```
+
+Tries to find element, if has no success throws an error
+
+#### `childExact`
+
+``` purescript
+childExact :: forall e o. Element -> Locator -> Selenium e o Element
+```
+
+Tries to find child, if has no success throws an error
+
+#### `startSpying`
+
+``` purescript
+startSpying :: forall e o. Selenium e o Unit
+```
+
+#### `stopSpying`
+
+``` purescript
+stopSpying :: forall e o. Selenium e o Unit
+```
+
+#### `clearLog`
+
+``` purescript
+clearLog :: forall e o. Selenium e o Unit
+```
+
+#### `getXHRStats`
+
+``` purescript
+getXHRStats :: forall e o. Selenium e o (List XHRStats)
+```
+
+

--- a/docs/Selenium/Types.md
+++ b/docs/Selenium/Types.md
@@ -114,6 +114,46 @@ data Capabilities :: *
 data FileDetector :: *
 ```
 
+#### `Method`
+
+``` purescript
+data Method
+  = DELETE
+  | GET
+  | HEAD
+  | OPTIONS
+  | PATCH
+  | POST
+  | PUT
+  | MOVE
+  | COPY
+  | CustomMethod String
+```
+
+Copied from `purescript-affjax` because the only thing we
+need from `affjax` is `Method`                    
+
+##### Instances
+``` purescript
+instance eqMethod :: Eq Method
+instance methodIsForeign :: IsForeign Method
+```
+
+#### `XHRState`
+
+``` purescript
+data XHRState
+  = Stale
+  | Opened
+  | Loaded
+```
+
+##### Instances
+``` purescript
+instance xhrStateEq :: Eq XHRState
+instance xhrStateIsForeign :: IsForeign XHRState
+```
+
 #### `Location`
 
 ``` purescript
@@ -125,6 +165,12 @@ type Location = { x :: Number, y :: Number }
 ``` purescript
 newtype ControlKey
   = ControlKey String
+```
+
+#### `XHRStats`
+
+``` purescript
+type XHRStats = { method :: Method, url :: String, async :: Boolean, user :: Maybe String, password :: Maybe String, state :: XHRState }
 ```
 
 

--- a/docs/Selenium/XHR.md
+++ b/docs/Selenium/XHR.md
@@ -1,0 +1,36 @@
+## Module Selenium.XHR
+
+#### `startSpying`
+
+``` purescript
+startSpying :: forall e. Driver -> Aff (selenium :: SELENIUM | e) Unit
+```
+
+Start spy on xhrs. It defines global variable in browser
+and put information about to it. 
+
+#### `stopSpying`
+
+``` purescript
+stopSpying :: forall e. Driver -> Aff (selenium :: SELENIUM | e) Unit
+```
+
+Return xhr's method to initial. Will not raise an error if hasn't been initiated
+
+#### `clearLog`
+
+``` purescript
+clearLog :: forall e. Driver -> Aff (selenium :: SELENIUM | e) Unit
+```
+
+Clean log. Will raise an error if spying hasn't been initiated
+
+#### `getStats`
+
+``` purescript
+getStats :: forall e. Driver -> Aff (selenium :: SELENIUM | e) (Array XHRStats)
+```
+
+Get recorded xhr stats. If spying has not been set will raise an error
+
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,10 @@ gulp.task("docs", function() {
             "Selenium.MouseButton": "docs/Selenium/MouseButton.md",
             "Selenium.Remote": "docs/Selenium/Remote.md",
             "Selenium.ScrollBehaviour": "docs/Selenium/ScrollBehaviour.md",
-            "Selenium.Types": "docs/Selenium/Types.md"
+            "Selenium.Types": "docs/Selenium/Types.md",
+            "Selenium.Monad": "docs/Selenium/Monad.md",
+            "Selenium.Combinators": "docs/Selenium/Combinators.md",
+            "Selenium.XHR": "docs/Selenium/XHR.md"
         }
     });
 });

--- a/src/Selenium.js
+++ b/src/Selenium.js
@@ -13,8 +13,13 @@ exports.get = function(driver) {
 
 exports.setFileDetector = function(driver) {
     return function(detector) {
-        return function () {
-          driver.setFileDetector(detector);
+        return function (cb, eb) {
+            try {
+                driver.setFileDetector(detector);
+                return cb();
+            } catch (e) {
+                return eb(e);
+            }
         };
     };
 };
@@ -125,6 +130,29 @@ function _find(nothing) {
     };
 }
 
+function _exact(driver) {
+    return function(by) {
+        return function(cb, eb) {
+            driver.isElementPresent(by)
+                .then(function(is) {
+                    if (is) {
+                        var el = driver.findElement(by);
+                        return cb(el);
+                    } else {
+                        return eb(new Error("element is not present"));
+                    }
+                })
+                .thenCatch(function(e) {
+                    return eb(e);
+                });
+                    
+        };
+    };
+}
+
+exports.findExact = _exact;
+exports.childExact = _exact;
+
 exports._findElement = _find;
 
 exports._findChild = _find;
@@ -223,7 +251,7 @@ exports.refresh = function(driver) {
     };
 };
 
-exports.to = function(url) {
+exports.naviagateTo = function(url) {
     return function(driver) {
         return function(cb, eb) {
             var n = new webdriver.WebDriver.Navigation(driver);

--- a/src/Selenium.purs
+++ b/src/Selenium.purs
@@ -12,10 +12,12 @@ module Selenium
        , findElements
        , findChild
        , findChildren
+       , findExact
+       , childExact
        , navigateBack
        , navigateForward
        , refresh
-       , to
+       , navigateTo
        , getCurrentUrl
        , executeStr
        , sendKeysEl
@@ -81,6 +83,8 @@ foreign import _findChild :: forall e a. Maybe a -> (a -> Maybe a) ->
                              Element -> Locator -> Aff (selenium :: SELENIUM|e) (Maybe Element)
 foreign import _findElements :: forall e. Driver -> Locator -> Aff (selenium :: SELENIUM|e) (Array Element)
 foreign import _findChildren :: forall e. Element -> Locator -> Aff (selenium :: SELENIUM|e) (Array Element)
+foreign import findExact :: forall e. Driver -> Locator -> Aff (selenium :: SELENIUM|e) Element 
+foreign import childExact :: forall e. Element -> Locator -> Aff (selenium :: SELENIUM|e) Element
 
 -- | Tries to find an element starting from `document` will return `Nothing` if there
 -- | is no element can be found by locator
@@ -101,12 +105,12 @@ findChildren :: forall e f. (Unfoldable f) => Element -> Locator -> Aff (seleniu
 findChildren el locator =
   unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> uncons xs) <$> (_findChildren el locator)
 
-foreign import setFileDetector :: forall e. Driver -> FileDetector -> Eff (selenium :: SELENIUM|e) Unit
+foreign import setFileDetector :: forall e. Driver -> FileDetector -> Aff (selenium :: SELENIUM|e) Unit 
 
 foreign import navigateBack :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
 foreign import navigateForward :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
 foreign import refresh :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
-foreign import to :: forall e. String -> Driver -> Aff (selenium :: SELENIUM|e) Unit
+foreign import navigateTo :: forall e. String -> Driver -> Aff (selenium :: SELENIUM|e) Unit
 foreign import getCurrentUrl :: forall e. Driver -> Aff (selenium :: SELENIUM|e) String
 foreign import getTitle :: forall e. Driver -> Aff (selenium :: SELENIUM|e) String
 -- | Executes javascript script from `String` argument.

--- a/src/Selenium/Combinators.purs
+++ b/src/Selenium/Combinators.purs
@@ -1,0 +1,92 @@
+module Selenium.Combinators where
+
+import Prelude
+import Control.Alt ((<|>))
+import Control.Monad.Trans (lift)
+import Data.Maybe (Maybe(), isJust, maybe)
+import Data.Maybe.Unsafe (fromJust)
+import Data.Either (Either(..), isRight, either)
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Eff.Exception (error, Error())
+import Selenium.Monad
+import Selenium.Types
+
+-- | Retry computation until it successed but not more then `n` times
+retry :: forall e o a. Int -> Selenium e o a -> Selenium e o a
+retry n action = do
+  res <- attempt action
+  case res of
+    Left e -> if n > one
+              then retry (n - one) action
+              else lift $ throwError $ error "To many retries"
+    Right r -> pure r
+
+-- | Tries to find element by string checks: css, xpath, id, name and classname
+tryFind :: forall e o. String -> Selenium e o Element
+tryFind probablyLocator =
+  (byCss probablyLocator >>= findExact) <|>
+  (byXPath probablyLocator >>= findExact) <|>
+  (byId probablyLocator >>= findExact) <|>
+  (byName probablyLocator >>= findExact) <|>
+  (byClassName probablyLocator >>= findExact)
+
+waitUntilJust :: forall e o a. Selenium e o (Maybe a) -> Int -> Selenium e o a
+waitUntilJust check time = do
+  wait (checker $ isJust <$> check) time
+  fromJust <$> check
+
+-- Tries to evaluate `Selenium` if it returns `false` after 500ms
+checker :: forall e o a. Selenium e o Boolean -> Selenium e o Boolean
+checker check = do
+  res <- check
+  if res
+    then pure true
+    else later 500 $ checker check
+
+getElementByCss :: forall e o. String -> Selenium e o Element
+getElementByCss cls =
+  byCss cls
+    >>= findElement
+    >>= maybe (throwError $ error $ "There is no element matching css: " <> cls) pure
+
+checkNotExistsByCss :: forall e o. String -> Selenium e o Unit
+checkNotExistsByCss = contra <<< getElementByCss 
+
+contra :: forall e o a. Selenium e o a -> Selenium e o Unit
+contra check = do
+  eR <- attempt check
+  either
+    (const $ pure unit)
+    (const $ throwError $ error "check successed in contra") eR 
+
+-- | takes value and repeatedly tries to evaluate it for timeout of ms (second arg)
+-- | if it evaluates w/o error returns its value
+-- | else throws error 
+waiter :: forall e o a. Selenium e o a -> Int -> Selenium e o a
+waiter getter timeout = do
+  wait (checker $ (isRight <$> attempt getter)) timeout
+  getter
+
+waitExistentCss :: forall e o. String -> Int -> Selenium e o Element
+waitExistentCss css timeout =
+  waiter (getElementByCss css) timeout
+
+waitNotExistentCss :: forall e o. String -> Int -> Selenium e o Unit
+waitNotExistentCss css timeout =
+  waiter (checkNotExistsByCss css) timeout
+
+
+-- | Repeatedly tries to evaluate check (third arg) for timeout ms (first arg)
+-- | finishes when check evaluates to true.
+-- | If there is an error during check or it constantly returns `false`
+-- | throws error with message (second arg)
+await :: forall e o. Int -> Selenium e o Boolean -> Selenium e o Unit
+await timeout check = do
+  ei <- attempt $ wait (checker check) timeout
+  case ei of
+    Left _ -> throwError $ error "await has no success"
+    Right _ -> pure unit 
+
+
+awaitUrlChanged :: forall e o. String -> Selenium e o Boolean
+awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getCurrentUrl 

--- a/src/Selenium/Monad.purs
+++ b/src/Selenium/Monad.purs
@@ -1,0 +1,192 @@
+-- | Most functions of `Selenium` use `Driver` as an argument
+-- | This module supposed to make code a bit cleaner through
+-- | putting `Driver` to `ReaderT`
+module Selenium.Monad where
+
+import Prelude
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Eff.Exception (error, Error())
+import Data.Either (Either())
+import Data.Maybe (Maybe())
+import Data.Foreign (Foreign())
+import Data.Maybe.Unsafe (fromJust)
+import Data.List
+import DOM
+import Selenium.Types
+import Control.Monad.Eff.Console (CONSOLE())
+import Control.Monad.Trans
+import Control.Monad.Reader.Trans
+import Control.Monad.Reader.Class
+import qualified Control.Monad.Aff as A
+import qualified Selenium as S
+import qualified Selenium.ActionSequence as S
+import qualified Selenium.XHR as S 
+-- | `Driver` is field of `ReaderT` context
+-- | Usually selenium tests are run with tons of configs (i.e. xpath locators,
+-- | timeouts) all those configs can be putted to `Selenium e o a`
+type Selenium e o a = 
+  ReaderT
+    {driver :: Driver |o} 
+    (A.Aff (console :: CONSOLE, selenium :: SELENIUM, dom :: DOM |e)) a
+
+-- | get driver from context
+getDriver :: forall e o. Selenium e o Driver 
+getDriver = _.driver <$> ask
+
+
+-- LIFT `Aff` combinators to `Selenium.Monad`
+apathize :: forall e o a. Selenium e o a -> Selenium e o Unit
+apathize check = ReaderT \r ->
+  A.apathize $ runReaderT check r
+
+attempt :: forall e o a. Selenium e o a -> Selenium e o (Either Error a)
+attempt check = ReaderT \r ->
+  A.attempt $ runReaderT check r
+
+later :: forall e o a. Int -> Selenium e o a -> Selenium e o a
+later time check = ReaderT \r ->
+  A.later' time $ runReaderT check r
+
+
+-- LIFT `Selenium` funcs to `Selenium.Monad`
+get :: forall e o. String -> Selenium e o Unit
+get url = 
+  getDriver >>= lift <<< flip S.get url
+
+wait :: forall e o. Selenium e o Boolean -> Int -> Selenium e o Unit
+wait check time = ReaderT \r ->
+  S.wait (runReaderT check r) time r.driver
+
+byCss :: forall e o. String -> Selenium e o Locator
+byCss = lift <<< S.byCss
+
+byXPath :: forall e o. String -> Selenium e o Locator
+byXPath = lift <<< S.byXPath
+
+byId :: forall e o. String -> Selenium e o Locator
+byId = lift <<< S.byId
+
+byName :: forall e o. String -> Selenium e o Locator
+byName = lift <<< S.byName
+
+byClassName :: forall e o. String -> Selenium e o Locator
+byClassName = lift <<< S.byClassName
+
+-- | get element by action returning an element
+-- | ```purescript
+-- | locator \el -> do 
+-- |   commonElements <- byCss ".common-element" >>= findElements el 
+-- |   flaggedElements <- traverse (\el -> Tuple el <$> isVisible el) commonElements
+-- |   maybe err pure $ foldl foldFn Nothing flaggedElements
+-- |   where
+-- |   err = throwError $ error "all common elements are not visible"
+-- |   foldFn Nothing (Tuple el true) = Just el
+-- |   foldFn a _ = a 
+-- | ```
+locator :: forall e o. (Element -> Selenium e o Element) -> Selenium e o Locator
+locator checkFn = ReaderT \r ->
+  S.affLocator (\el -> runReaderT (checkFn el) r)
+
+-- | Tries to find element and return it wrapped in `Just` 
+findElement :: forall e o. Locator -> Selenium e o (Maybe Element) 
+findElement locator =
+  getDriver >>= lift <<< flip S.findElement locator
+
+findElements :: forall e o. Locator -> Selenium e o (List Element)
+findElements locator = 
+  getDriver >>= lift <<< flip S.findElements locator
+
+-- | Tries to find child and return it wrapped in `Just`
+findChild :: forall e o. Element -> Locator -> Selenium e o (Maybe Element)
+findChild el loc = lift $ S.findChild el loc
+
+findChildren :: forall e o. Element -> Locator -> Selenium e o (List Element)
+findChildren el loc = lift $ S.findChildren el loc
+
+getInnerHtml :: forall e o. Element -> Selenium e o String
+getInnerHtml = lift <<< S.getInnerHtml
+
+isDisplayed :: forall e o. Element -> Selenium e o Boolean
+isDisplayed = lift <<< S.isDisplayed
+
+isEnabled :: forall e o. Element -> Selenium e o Boolean
+isEnabled = lift <<< S.isEnabled
+
+getCssValue :: forall e o. Element -> String -> Selenium e o String
+getCssValue el key = lift $ S.getCssValue el key
+
+getAttribute :: forall e o. Element -> String -> Selenium e o String
+getAttribute el attr = lift $ S.getAttribute el attr
+
+clearEl :: forall e o. Element -> Selenium e o Unit
+clearEl = lift <<< S.clearEl
+
+sendKeysEl :: forall e o. String -> Element -> Selenium e o Unit
+sendKeysEl ks el = lift $ S.sendKeysEl ks el
+
+script :: forall e o. String -> Selenium e o Foreign
+script str =
+  getDriver >>= flip S.executeStr str >>> lift
+
+getCurrentUrl :: forall e o. Selenium e o String
+getCurrentUrl = getDriver >>= S.getCurrentUrl >>> lift
+
+navigateBack :: forall e o. Selenium e o Unit
+navigateBack = getDriver >>= S.navigateBack >>> lift
+
+navigateForward :: forall e o. Selenium e o Unit
+navigateForward = getDriver >>= S.navigateForward >>> lift
+
+navigateTo :: forall e o. String -> Selenium e o Unit
+navigateTo url = getDriver >>= S.navigateTo url >>> lift
+
+setFileDetector :: forall e o. FileDetector -> Selenium e o Unit
+setFileDetector fd = getDriver >>= flip S.setFileDetector fd >>> lift
+
+getTitle :: forall e o. Selenium e o String
+getTitle = getDriver >>= S.getTitle >>> lift
+
+
+-- | Run sequence of actions 
+sequence :: forall e o. S.Sequence Unit -> Selenium e o Unit
+sequence seq = do
+  getDriver >>= lift <<< flip S.sequence seq
+
+-- | Same as `sequence` but takes function of `ReaderT` as an argument
+actions :: forall e o. ({driver :: Driver |o} -> S.Sequence Unit) -> Selenium e o Unit 
+actions seqFn = do 
+  ctx <- ask
+  sequence $ seqFn ctx
+
+-- | Stop computations
+stop :: forall e o. Selenium e o Unit
+stop = wait (later top $ pure false) top
+
+refresh :: forall e o. Selenium e o Unit
+refresh = getDriver >>= S.refresh >>> lift 
+
+quit :: forall e o. Selenium e o Unit
+quit = getDriver >>= S.quit >>> lift
+
+takeScreenshot :: forall e o. Selenium e o String
+takeScreenshot = getDriver >>= S.takeScreenshot >>> lift
+
+-- | Tries to find element, if has no success throws an error
+findExact :: forall e o. Locator -> Selenium e o Element
+findExact loc = getDriver >>= flip S.findExact loc >>> lift 
+
+-- | Tries to find child, if has no success throws an error
+childExact :: forall e o. Element -> Locator -> Selenium e o Element
+childExact el loc = lift $ S.childExact el loc 
+
+startSpying :: forall e o. Selenium e o Unit
+startSpying = getDriver >>= S.startSpying >>> lift 
+
+stopSpying :: forall e o. Selenium e o Unit
+stopSpying = getDriver >>= S.stopSpying >>> lift
+
+clearLog :: forall e o. Selenium e o Unit
+clearLog = getDriver >>= S.clearLog >>> lift
+
+getXHRStats :: forall e o. Selenium e o (List XHRStats)
+getXHRStats = getDriver >>= S.getStats >>> map toList >>> lift

--- a/src/Selenium/Types.purs
+++ b/src/Selenium/Types.purs
@@ -1,5 +1,12 @@
 module Selenium.Types where
 
+import Prelude
+import Data.Foreign.Class (IsForeign)
+import Data.Foreign (readString, ForeignError(..))
+import Data.String (toLower)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe())
+
 foreign import data Builder :: *
 foreign import data SELENIUM :: !
 foreign import data Driver :: *
@@ -20,6 +27,70 @@ foreign import data ScrollBehaviour :: *
 foreign import data Capabilities :: *
 foreign import data FileDetector :: *
 
+-- | Copied from `purescript-affjax` because the only thing we
+-- | need from `affjax` is `Method`                    
+data Method
+  = DELETE
+  | GET
+  | HEAD
+  | OPTIONS
+  | PATCH
+  | POST
+  | PUT
+  | MOVE
+  | COPY
+  | CustomMethod String
+
+instance eqMethod :: Eq Method where
+  eq DELETE DELETE = true
+  eq GET GET = true
+  eq HEAD HEAD = true
+  eq OPTIONS OPTIONS = true
+  eq PATCH PATCH = true
+  eq POST POST = true
+  eq PUT PUT = true
+  eq MOVE MOVE = true
+  eq COPY COPY = true
+  eq (CustomMethod a) (CustomMethod b) = a == b
+  eq _ _ = false 
+  
+
+instance methodIsForeign :: IsForeign Method where
+  read f = do
+    str <- readString f
+    pure $ case toLower str of
+      "delete" -> DELETE
+      "get" -> GET
+      "head" -> HEAD
+      "options" -> OPTIONS
+      "patch" -> PATCH
+      "post" -> POST
+      "put" -> PUT
+      "move" -> MOVE
+      "copy" -> COPY
+      a -> CustomMethod a 
+
+data XHRState
+  = Stale
+  | Opened
+  | Loaded
+
+instance xhrStateEq :: Eq XHRState where
+  eq Stale Stale = true
+  eq Opened Opened = true
+  eq Loaded Loaded = true
+  eq _ _ = false
+
+instance xhrStateIsForeign :: IsForeign XHRState where
+  read f = do
+    str <- readString f
+    case str of
+      "stale" -> pure Stale
+      "opened" -> pure Opened
+      "loaded" -> pure Loaded 
+      _ -> Left $ TypeMismatch "xhr state" "string"
+
+    
 
 type Location =
   { x :: Number
@@ -27,3 +98,13 @@ type Location =
   }
 
 newtype ControlKey = ControlKey String
+
+
+type XHRStats =
+  { method :: Method 
+  , url :: String
+  , async :: Boolean
+  , user :: Maybe String
+  , password :: Maybe String
+  , state :: XHRState
+  } 

--- a/src/Selenium/XHR.purs
+++ b/src/Selenium/XHR.purs
@@ -1,0 +1,156 @@
+module Selenium.XHR where
+
+import Prelude
+import Data.Either (either, Either(..))
+import Data.Traversable (for)
+import Selenium (executeStr)
+import Selenium.Types
+import Control.Monad.Aff (Aff())
+import Control.Monad.Error.Class (throwError)
+import Control.Monad.Eff.Exception (error)
+import Data.Foreign (readBoolean, isUndefined, readArray)
+import Data.Foreign.Class (readProp)
+import Data.Foreign.NullOrUndefined (runNullOrUndefined)
+
+-- | Start spy on xhrs. It defines global variable in browser
+-- | and put information about to it. 
+startSpying :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
+startSpying driver = void $ 
+  executeStr driver """
+"use strict"
+// If we have activated spying
+if (window.__SELENIUM__) {
+  // and it stopped
+  if (!window.__SELENIUM__.isActive) {
+    window.__SELENIUM__.spy();
+  }
+} else {
+  var Selenium = {
+      isActive: false,
+      log: [],
+      count: 0,
+      spy: function() {
+          // monkey patch
+          var open = XMLHttpRequest.prototype.open;
+          window.XMLHttpRequest.prototype.open =
+              function(method, url, async, user, password) {
+                  // we need this mark to update log after
+                  // request is finished
+                  this.__id = Selenium.count;
+                  Selenium.log[this.__id] = {
+                      method: method,
+                      url: url,
+                      async: async,
+                      user: user,
+                      password: password,
+                      state: "stale"
+                  };
+                  Selenium.count++;
+                  open.apply(this, arguments);
+              };
+          // another monkey patch
+          var send = XMLHttpRequest.prototype.send;
+          window.XMLHttpRequest.prototype.send =
+              function(data) {
+                  // this request can be deleted (this.clean() i.e.) 
+                  if (Selenium.log[this.__id]) {
+                      Selenium.log[this.__id].state = "opened";
+                  }
+                  // monkey pathc `onload` (I suppose it's useless to fire xhr
+                  // without `onload` handler, but to be sure there is check for
+                  // type of current value 
+                  var m = this.onload;
+                  this.onload = function() {
+                      if (Selenium.log[this.__id]) {
+                          Selenium.log[this.__id].state = "loaded";
+                      }
+                      if (typeof m == 'function') {
+                          m();
+                      }
+                  };
+                  send.apply(this, arguments);
+              };
+          // monkey patch `abort`          
+          var abort = window.XMLHttpRequest.prototype.abort;
+          window.XMLHttpRequest.prototype.abort = function() {
+              if (Selenium.log[this.__id]) {
+                  Selenium.log[this.__id].state = "aborted";
+              }
+              abort.apply(this, arguments);
+          };
+          this.isActive = true;
+          // if we define it here we need not to make `send` global 
+          Selenium.unspy = function() {
+              this.active = false;
+              window.XMLHttpRequest.send = send;
+              window.XMLHttpRequest.open = open;
+              window.XMLHttpRequest.abort = abort;
+          };
+      },
+      // just clean log
+      clean: function() {
+          this.log = [];
+      }
+  };
+  window.__SELENIUM__ = Selenium;
+  Selenium.spy();
+}
+"""
+
+-- | Return xhr's method to initial. Will not raise an error if hasn't been initiated
+stopSpying :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
+stopSpying driver = void $ executeStr driver """
+if (window.__SELENIUM__) {
+    window.__SELENIUM__.unspy();
+}
+"""
+
+-- | Clean log. Will raise an error if spying hasn't been initiated
+clearLog :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit 
+clearLog driver = do 
+  success <- executeStr driver """
+  if (!window.__SELENIUM__) {
+    return false;
+  }
+  else {
+    window.__SELENIUM__.clean();
+    return true;
+  }
+  """
+  case readBoolean success of
+    Right true -> pure unit
+    _ -> throwError $ error "spying is inactive"
+
+-- | Get recorded xhr stats. If spying has not been set will raise an error
+getStats :: forall e. Driver -> Aff (selenium :: SELENIUM|e) (Array XHRStats)
+getStats driver = do 
+  log <- executeStr driver """
+  if (!window.__SELENIUM__) {
+    return undefined;
+  }
+  else {
+    return window.__SELENIUM__.log;
+  }
+  """
+  if isUndefined log
+    then throwError $ error "spying is inactive"
+    else pure unit
+  either (const $ throwError $ error "incorrect log") pure do
+    arr <- readArray log
+    for arr \el -> do
+      state <- readProp "state" el
+      method <- readProp "method" el
+      url <- readProp "url" el
+      async <- readProp "async" el
+      password <- runNullOrUndefined <$> readProp "password" el
+      user <- runNullOrUndefined <$> readProp "user" el
+      pure { state: state
+           , method: method
+           , url: url
+           , async: async
+           , password: password
+           , user: user
+           }
+  
+
+


### PR DESCRIPTION
* Extracted combinators from slamdata. But, changed their names to mimic `Selenium` module and webdriver method names. 
* Added xhr-spy. (Now we can in example wait until next `PUT` request will be replied)
* switched from `Eff` to `Aff` in `setFileDetector`, it's not really necessary, but all other functions in that module are `Aff`s 
* checked by `cryogenian/slamdata#245d2e6c6de65b897a1a102724a9d32cd953b8f7`