### PR TITLE
Added repeatedlyTryTo function

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "purescript-base": "^0.2.0",
     "purescript-aff": "^0.11.3",
+    "purescript-aff-reattempt": "^0.1.0",
+    "purescript-base": "^0.2.0",
     "purescript-dom": "^0.2.4"
   }
 }

--- a/docs/Selenium/Monad.md
+++ b/docs/Selenium/Monad.md
@@ -7,7 +7,7 @@ putting `Driver` to `ReaderT`
 #### `Selenium`
 
 ``` purescript
-type Selenium e o a = ReaderT { driver :: Driver | o } (Aff (console :: CONSOLE, selenium :: SELENIUM, dom :: DOM | e)) a
+type Selenium e o a = ReaderT { driver :: Driver, defaultTimeout :: Int | o } (Aff (console :: CONSOLE, selenium :: SELENIUM, dom :: DOM, ref :: REF | e)) a
 ```
 
 `Driver` is field of `ReaderT` context
@@ -93,6 +93,22 @@ get :: forall e o. String -> Selenium e o Unit
 ``` purescript
 wait :: forall e o. Selenium e o Boolean -> Int -> Selenium e o Unit
 ```
+
+#### `tryRepeatedlyTo'`
+
+``` purescript
+tryRepeatedlyTo' :: forall a e o. Int -> Selenium e o a -> Selenium e o a
+```
+
+Tries the provided Selenium computation repeatedly until the provided timeout expires
+
+#### `tryRepeatedlyTo`
+
+``` purescript
+tryRepeatedlyTo :: forall a e o. Selenium e o a -> Selenium e o a
+```
+
+Tries the provided Selenium computation repeatedly until `Selenium`'s defaultTimeout expires
 
 #### `byCss`
 
@@ -283,7 +299,7 @@ Run sequence of actions
 #### `actions`
 
 ``` purescript
-actions :: forall e o. ({ driver :: Driver | o } -> Sequence Unit) -> Selenium e o Unit
+actions :: forall e o. ({ driver :: Driver, defaultTimeout :: Int | o } -> Sequence Unit) -> Selenium e o Unit
 ```
 
 Same as `sequence` but takes function of `ReaderT` as an argument

--- a/src/Selenium.purs
+++ b/src/Selenium.purs
@@ -63,6 +63,7 @@ foreign import get :: forall e. Driver -> String -> Aff (selenium :: SELENIUM|e)
 foreign import wait :: forall e. Aff (selenium :: SELENIUM|e) Boolean ->
                                  Int -> Driver ->
                                  Aff (selenium :: SELENIUM|e) Unit
+
 -- | Finalizer
 foreign import quit :: forall e. Driver -> Aff (selenium :: SELENIUM|e) Unit
 

--- a/src/Selenium/Combinators.purs
+++ b/src/Selenium/Combinators.purs
@@ -59,23 +59,6 @@ contra check = do
     (const $ pure unit)
     (const $ throwError $ error "check successed in contra") eR 
 
--- | takes value and repeatedly tries to evaluate it for timeout of ms (second arg)
--- | if it evaluates w/o error returns its value
--- | else throws error 
-waiter :: forall e o a. Selenium e o a -> Int -> Selenium e o a
-waiter getter timeout = do
-  wait (checker $ (isRight <$> attempt getter)) timeout
-  getter
-
-waitExistentCss :: forall e o. String -> Int -> Selenium e o Element
-waitExistentCss css timeout =
-  waiter (getElementByCss css) timeout
-
-waitNotExistentCss :: forall e o. String -> Int -> Selenium e o Unit
-waitNotExistentCss css timeout =
-  waiter (checkNotExistsByCss css) timeout
-
-
 -- | Repeatedly tries to evaluate check (third arg) for timeout ms (first arg)
 -- | finishes when check evaluates to true.
 -- | If there is an error during check or it constantly returns `false`
@@ -86,7 +69,6 @@ await timeout check = do
   case ei of
     Left _ -> throwError $ error "await has no success"
     Right _ -> pure unit 
-
 
 awaitUrlChanged :: forall e o. String -> Selenium e o Boolean
 awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getCurrentUrl 


### PR DESCRIPTION
This repeatedly makes attempts to run a webdriver computation until a timeout is reached. Unlike combinators like `waiter` it doesn't rely on a `Boolean` predicate nor does it hide `Error`s thrown by webdriver computations.