### PR TITLE
Update build; fix warnings & trailing whitespace

### DIFF
--- a/docs/Selenium/ActionSequence.md
+++ b/docs/Selenium/ActionSequence.md
@@ -1,6 +1,6 @@
 ## Module Selenium.ActionSequence
 
-DSL for building action sequences 
+DSL for building action sequences
 
 #### `Sequence`
 

--- a/docs/Selenium/Combinators.md
+++ b/docs/Selenium/Combinators.md
@@ -25,7 +25,7 @@ waitUntilJust :: forall e o a. Selenium e o (Maybe a) -> Int -> Selenium e o a
 #### `checker`
 
 ``` purescript
-checker :: forall e o a. Selenium e o Boolean -> Selenium e o Boolean
+checker :: forall e o. Selenium e o Boolean -> Selenium e o Boolean
 ```
 
 #### `getElementByCss`

--- a/example/src/Example/Main.purs
+++ b/example/src/Example/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Exception (EXCEPTION())
-import Control.Monad.Aff (Aff(), launchAff, later')
+import Control.Monad.Aff (launchAff, later')
 import Control.Monad.Aff.Console (log)
 import Data.Maybe (maybe)
 import Selenium

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "gulp": "^3.9.0",
-    "gulp-purescript": "^0.5.0",
-    "purescript": "^0.7.4",
+    "gulp-purescript": "^0.8.0",
+    "purescript": "^0.7.6",
     "selenium-webdriver": "^2.46.1"
   }
 }

--- a/src/Selenium.purs
+++ b/src/Selenium.purs
@@ -51,12 +51,10 @@ module Selenium
        ) where
 
 import Prelude
-import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
 import Data.Maybe (Maybe())
 import Data.Either (either)
-import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Aff (Aff(), attempt)
 import Selenium.Types
 import Data.Unfoldable (Unfoldable, unfoldr)
@@ -64,7 +62,6 @@ import Data.Foreign (Foreign())
 import Data.Maybe (Maybe(..))
 import Data.Array (uncons)
 import Data.Tuple (Tuple(..))
-import DOM (DOM())
 
 -- | Go to url
 foreign import get :: forall e. Driver -> String -> Aff (selenium :: SELENIUM|e) Unit

--- a/src/Selenium/ActionSequence.purs
+++ b/src/Selenium/ActionSequence.purs
@@ -1,4 +1,4 @@
--- | DSL for building action sequences 
+-- | DSL for building action sequences
 module Selenium.ActionSequence
        ( sequence
        , keyUp
@@ -17,7 +17,6 @@ module Selenium.ActionSequence
 import Prelude
 import Selenium.Types
 import Selenium.MouseButton
-import Control.Monad.Eff
 import Data.List
 import Data.Function
 import Data.Foldable (foldl)
@@ -26,17 +25,17 @@ import Control.Monad.Writer.Class (tell)
 import Control.Monad.Aff (Aff())
 
 data Command
-  = Click MouseButton Element 
-  | DoubleClick MouseButton Element 
-  | KeyDown ControlKey 
-  | KeyUp ControlKey 
-  | MouseDown MouseButton Element 
-  | MouseToElement Element 
-  | MouseToLocation Location 
+  = Click MouseButton Element
+  | DoubleClick MouseButton Element
+  | KeyDown ControlKey
+  | KeyUp ControlKey
+  | MouseDown MouseButton Element
+  | MouseToElement Element
+  | MouseToLocation Location
   | MouseUp MouseButton Element
   | DnDToElement Element Element
-  | DnDToLocation Element Location 
-  | SendKeys String 
+  | DnDToLocation Element Location
+  | SendKeys String
 
 newtype Sequence a = Sequence (Writer (List Command) a)
 
@@ -58,40 +57,40 @@ instance applicativeSequence :: Applicative Sequence where
 instance monadSequence :: Monad Sequence
 
 rule :: Command -> Sequence Unit
-rule = Sequence <<< tell <<< singleton 
+rule = Sequence <<< tell <<< singleton
 
 
-click :: MouseButton -> Element -> Sequence Unit 
+click :: MouseButton -> Element -> Sequence Unit
 click btn el = rule $ Click btn el
 
-leftClick :: Element -> Sequence Unit 
+leftClick :: Element -> Sequence Unit
 leftClick = click leftButton
 
-doubleClick :: MouseButton -> Element -> Sequence Unit 
-doubleClick btn el = rule $ DoubleClick btn el 
+doubleClick :: MouseButton -> Element -> Sequence Unit
+doubleClick btn el = rule $ DoubleClick btn el
 
-hover :: Element -> Sequence Unit 
-hover el = rule $ MouseToElement el 
+hover :: Element -> Sequence Unit
+hover el = rule $ MouseToElement el
 
-mouseDown :: MouseButton -> Element -> Sequence Unit 
-mouseDown btn el = rule $ MouseDown btn el 
+mouseDown :: MouseButton -> Element -> Sequence Unit
+mouseDown btn el = rule $ MouseDown btn el
 
-mouseUp :: MouseButton -> Element -> Sequence Unit 
-mouseUp btn el = rule $ MouseUp btn el 
+mouseUp :: MouseButton -> Element -> Sequence Unit
+mouseUp btn el = rule $ MouseUp btn el
 
-sendKeys :: String -> Sequence Unit 
-sendKeys keys = rule $ SendKeys keys 
+sendKeys :: String -> Sequence Unit
+sendKeys keys = rule $ SendKeys keys
 
-mouseToLocation :: Location -> Sequence Unit 
-mouseToLocation loc = rule $ MouseToLocation loc 
+mouseToLocation :: Location -> Sequence Unit
+mouseToLocation loc = rule $ MouseToLocation loc
 
 -- | This function is used only with special keys (META, CONTROL, etc)
 -- | It doesn't emulate __keyDown__ event
-keyDown :: ControlKey -> Sequence Unit 
-keyDown k = rule $ KeyDown k 
+keyDown :: ControlKey -> Sequence Unit
+keyDown k = rule $ KeyDown k
 -- | This function is used only with special keys (META, CONTROL, etc)
 -- | It doesn't emulate __keyUp__ event
-keyUp :: ControlKey -> Sequence Unit 
+keyUp :: ControlKey -> Sequence Unit
 keyUp k = rule $ KeyUp k
 
 dndToElement :: Element -> Element -> Sequence Unit
@@ -107,7 +106,7 @@ sequence driver commands = do
 
 interpret :: List Command -> ActionSequence -> ActionSequence
 interpret commands seq =
-  foldl foldFn seq commands 
+  foldl foldFn seq commands
   where
   foldFn :: ActionSequence -> Command -> ActionSequence
   foldFn seq (Click btn el) = runFn3 _click seq btn el

--- a/src/Selenium/Builder.purs
+++ b/src/Selenium/Builder.purs
@@ -12,13 +12,10 @@ module Selenium.Builder
 import Prelude
 import Selenium.Types
 import Selenium.Browser
-import Control.Monad.Eff
 import Data.Tuple
 import Data.List
 import Data.Function
-import Data.Monoid (mempty)
 import Data.Foldable (foldl)
-import Data.Foreign (toForeign)
 import Control.Monad.Writer (Writer(), execWriter)
 import Control.Monad.Writer.Class (tell)
 import Control.Monad.Aff (Aff())

--- a/src/Selenium/Combinators.purs
+++ b/src/Selenium/Combinators.purs
@@ -5,9 +5,9 @@ import Control.Alt ((<|>))
 import Control.Monad.Trans (lift)
 import Data.Maybe (Maybe(), isJust, maybe)
 import Data.Maybe.Unsafe (fromJust)
-import Data.Either (Either(..), isRight, either)
+import Data.Either (Either(..), either)
 import Control.Monad.Error.Class (throwError)
-import Control.Monad.Eff.Exception (error, Error())
+import Control.Monad.Eff.Exception (error)
 import Selenium.Monad
 import Selenium.Types
 
@@ -36,7 +36,7 @@ waitUntilJust check time = do
   fromJust <$> check
 
 -- Tries to evaluate `Selenium` if it returns `false` after 500ms
-checker :: forall e o a. Selenium e o Boolean -> Selenium e o Boolean
+checker :: forall e o. Selenium e o Boolean -> Selenium e o Boolean
 checker check = do
   res <- check
   if res
@@ -50,14 +50,14 @@ getElementByCss cls =
     >>= maybe (throwError $ error $ "There is no element matching css: " <> cls) pure
 
 checkNotExistsByCss :: forall e o. String -> Selenium e o Unit
-checkNotExistsByCss = contra <<< getElementByCss 
+checkNotExistsByCss = contra <<< getElementByCss
 
 contra :: forall e o a. Selenium e o a -> Selenium e o Unit
 contra check = do
   eR <- attempt check
   either
     (const $ pure unit)
-    (const $ throwError $ error "check successed in contra") eR 
+    (const $ throwError $ error "check successed in contra") eR
 
 -- | Repeatedly attempts to find an element using the provided selector until the
 -- | provided timeout elapses.
@@ -78,7 +78,7 @@ await timeout check = do
   ei <- attempt $ wait (checker check) timeout
   case ei of
     Left _ -> throwError $ error "await has no success"
-    Right _ -> pure unit 
+    Right _ -> pure unit
 
 awaitUrlChanged :: forall e o. String -> Selenium e o Boolean
-awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getCurrentUrl 
+awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getCurrentUrl

--- a/src/Selenium/FFProfile.purs
+++ b/src/Selenium/FFProfile.purs
@@ -17,7 +17,7 @@ import Prelude
 import Control.Monad.Aff (Aff())
 import Selenium.Capabilities
 import Selenium.Types
-import Data.List (List(..), singleton)
+import Data.List (List(), singleton)
 import Data.Foldable (foldl)
 import Data.Foreign (Foreign())
 import Control.Monad.Writer (Writer(), execWriter)
@@ -79,7 +79,7 @@ interpret commands b = foldl foldFn b commands
   foldFn p (SetPreference k v) = _setFFPreference k v p
 
 
-foreign import _setFFPreference :: forall e. String -> FFPreference -> FFProfile -> FFProfile
+foreign import _setFFPreference :: String -> FFPreference -> FFProfile -> FFProfile
 foreign import _newFFProfile :: forall e. Aff (selenium :: SELENIUM|e) FFProfile
 foreign import _encode :: forall e. FFProfile -> Aff (selenium :: SELENIUM|e) Capabilities
 

--- a/src/Selenium/Monad.purs
+++ b/src/Selenium/Monad.purs
@@ -4,18 +4,15 @@
 module Selenium.Monad where
 
 import Prelude
-import Control.Monad.Error.Class (throwError)
-import Control.Monad.Eff.Exception (error, Error())
+import Control.Monad.Eff.Exception (Error())
 import Data.Either (Either())
 import Data.Maybe (Maybe())
 import Data.Foreign (Foreign())
-import Data.Maybe.Unsafe (fromJust)
 import Data.List
 import DOM
 import Selenium.Types
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Ref (REF())
-import Control.Monad.Trans
 import Control.Monad.Reader.Trans
 import Control.Monad.Reader.Class
 import qualified Control.Monad.Aff as A


### PR DESCRIPTION
- Updated the build to use PureScript 0.7.6
- Updated the build to use a newer version of `gulp-purescript` that doesn't swallow up all warnings
- Fixed warnings (unused imports, unnecessary quantification)
- Removed trailing whitespace from a few files

(Related to [SD-941](https://slamdata.atlassian.net/browse/SD-941))