### PR TITLE
Upgrade to use PureScript 0.9.1 and update all dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "purescript-aff": "^1.0.0",
-    "purescript-aff-reattempt": "git://github.com/daniel-chambers/purescript-aff-reattempt.git#249a49bbbdffdf31ec70ec3e2e0458e1a7a84084",
+    "purescript-aff-reattempt": "^1.0.0",
     "purescript-base": "^1.0.0",
     "purescript-dom": "^1.1.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -17,9 +17,9 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "purescript-aff": "^0.16.0",
-    "purescript-aff-reattempt": "^0.3.0",
-    "purescript-base": "^0.2.0",
-    "purescript-dom": "^0.2.4"
+    "purescript-aff": "^1.0.0",
+    "purescript-aff-reattempt": "git://github.com/daniel-chambers/purescript-aff-reattempt.git#249a49bbbdffdf31ec70ec3e2e0458e1a7a84084",
+    "purescript-base": "^1.0.0",
+    "purescript-dom": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "pulp build"
+    "build": "pulp build",
+    "bower": "bower"
   },
   "devDependencies": {
-    "pulp": "^8.1.0",
-    "purescript": "^0.7.6",
-    "rimraf": "^2.5.2"
+    "pulp": "^9.0.1",
+    "purescript": "^0.9.1",
+    "rimraf": "^2.5.3",
+    "bower": "^1.7.1"
   }
 }

--- a/src/Selenium.purs
+++ b/src/Selenium.purs
@@ -57,7 +57,7 @@ import Data.Maybe (Maybe())
 import Data.Either (either)
 import Control.Monad.Aff (Aff(), attempt)
 import Selenium.Types
-import Data.Unfoldable (Unfoldable, unfoldr)
+import Data.Unfoldable (class Unfoldable, unfoldr)
 import Data.Foreign (Foreign())
 import Data.Maybe (Maybe(..))
 import Data.Array (uncons)
@@ -116,7 +116,7 @@ loseElement driver locator = do
   result <- attempt $ findExact driver locator
   either (const $ pure unit) (const $ throwError $ error failMessage) result
     where
-    failMessage = "Found element with locator: " ++ showLocator locator
+    failMessage = "Found element with locator: " <> showLocator locator
 
 -- | Finds elements by locator from `document`
 findElements :: forall e f. (Unfoldable f) => Driver -> Locator -> Aff (selenium :: SELENIUM|e) (f Element)

--- a/src/Selenium/ActionSequence.purs
+++ b/src/Selenium/ActionSequence.purs
@@ -20,7 +20,7 @@ import Prelude
 import Selenium.Types
 import Selenium.MouseButton
 import Data.List
-import Data.Function
+import Data.Function.Uncurried
 import Data.Foldable (foldl)
 import Control.Monad.Writer (Writer(), execWriter)
 import Control.Monad.Writer.Class (tell)

--- a/src/Selenium/Builder.purs
+++ b/src/Selenium/Builder.purs
@@ -14,7 +14,7 @@ import Selenium.Types
 import Selenium.Browser
 import Data.Tuple
 import Data.List
-import Data.Function
+import Data.Function.Uncurried
 import Data.Foldable (foldl)
 import Control.Monad.Writer (Writer(), execWriter)
 import Control.Monad.Writer.Class (tell)

--- a/src/Selenium/Combinators.purs
+++ b/src/Selenium/Combinators.purs
@@ -4,7 +4,6 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Monad.Trans (lift)
 import Data.Maybe (Maybe(), isJust, maybe)
-import Data.Maybe.Unsafe (fromJust)
 import Data.Either (Either(..), either)
 import Control.Monad.Error.Class (throwError)
 import Control.Monad.Eff.Exception (error)
@@ -33,7 +32,7 @@ tryFind probablyLocator =
 waitUntilJust :: forall e o a. Selenium e o (Maybe a) -> Int -> Selenium e o a
 waitUntilJust check time = do
   wait (checker $ isJust <$> check) time
-  fromJust <$> check
+  check >>= maybe (throwError $ error $ "Maybe was not Just after waiting for isJust") pure
 
 -- Tries to evaluate `Selenium` if it returns `false` after 500ms
 checker :: forall e o. Selenium e o Boolean -> Selenium e o Boolean
@@ -81,4 +80,4 @@ await timeout check = do
     Right _ -> pure unit
 
 awaitUrlChanged :: forall e o. String -> Selenium e o Boolean
-awaitUrlChanged oldURL = checker $ (oldURL /=) <$> getCurrentUrl
+awaitUrlChanged oldURL = checker $ (oldURL /= _) <$> getCurrentUrl

--- a/src/Selenium/Monad.purs
+++ b/src/Selenium/Monad.purs
@@ -15,11 +15,11 @@ import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Ref (REF())
 import Control.Monad.Reader.Trans
 import Control.Monad.Reader.Class
-import qualified Control.Monad.Aff as A
-import qualified Control.Monad.Aff.Reattempt as A
-import qualified Selenium as S
-import qualified Selenium.ActionSequence as S
-import qualified Selenium.XHR as S
+import Control.Monad.Aff as A
+import Control.Monad.Aff.Reattempt as A
+import Selenium as S
+import Selenium.ActionSequence as S
+import Selenium.XHR as S
 -- | `Driver` is field of `ReaderT` context
 -- | Usually selenium tests are run with tons of configs (i.e. xpath locators,
 -- | timeouts) all those configs can be putted to `Selenium e o a`
@@ -236,7 +236,7 @@ clearLog :: forall e o. Selenium e o Unit
 clearLog = getDriver >>= S.clearLog >>> lift
 
 getXHRStats :: forall e o. Selenium e o (List XHRStats)
-getXHRStats = getDriver >>= S.getStats >>> map toList >>> lift
+getXHRStats = getDriver >>= S.getStats >>> map fromFoldable >>> lift
 
 
 getWindowHandle :: forall e o. Selenium e o WindowHandle

--- a/src/Selenium/Types.purs
+++ b/src/Selenium/Types.purs
@@ -1,7 +1,7 @@
 module Selenium.Types where
 
 import Prelude
-import Data.Foreign.Class (IsForeign)
+import Data.Foreign.Class (class IsForeign)
 import Data.Foreign (readString, ForeignError(..))
 import Data.String (toLower)
 import Data.Either (Either(..))


### PR DESCRIPTION
This upgrades the code to work with PureScript v0.9.1 and updated dependencies. I have a PR open to update the dependency `purescript-aff-reattempt` to PS 0.9 (https://github.com/slamdata/purescript-aff-reattempt/pull/13), so while that's unmerged I've pinned this library to use that PR's code. Of course, that means we shouldn't merge this PR until that one is in and we can properly set the version in bower.json. :)

There's also one place in the code that was using a partial function that I've worked around for now, but I wonder if there isn't a better way of doing it. I'll put a comment inline on that bit of code so we can discuss it.