### PR TITLE
Add missing keys

### DIFF
--- a/src/Selenium/Key.js
+++ b/src/Selenium/Key.js
@@ -2,8 +2,71 @@
 
 var k = require("selenium-webdriver").Key;
 
-exports.altKey = k.ALT;
-exports.controlKey = k.CONTROL;
+exports.nullKey = k.NULL;
+exports.cancelKey = k.CANCEL;
+exports.helpKey = k.HELP;
+exports.backSpaceKey = k.BACK_SPACE;
+exports.tabKey = k.TAB;
+exports.clearKey = k.CLEAR;
+exports.returnKey = k.RETURN;
+exports.enterKey = k.ENTER;
 exports.shiftKey = k.SHIFT;
+exports.controlKey = k.CONTROL;
+exports.altKey = k.ALT;
+exports.pauseKey = k.PAUSE;
+exports.escapeKey = k.ESCAPE;
+exports.spaceKey = k.SPACE;
+exports.pageUpKey = k.PAGE_UP;
+exports.pageDownKey = k.PAGE_DOWN;
+exports.endKey = k.END;
+exports.homeKey = k.HOME;
+exports.arrowLeftKey = k.ARROW_LEFT;
+exports.leftKey = k.LEFT;
+exports.arrowUpKey = k.ARROW_UP;
+exports.upKey = k.UP;
+exports.arrowRightKey = k.ARROW_RIGHT;
+exports.rightKey = k.RIGHT;
+exports.arrowDownKey = k.ARROW_DOWN;
+exports.downKey = k.DOWN;
+
+exports.insertKey = k.INSERT;
+exports.deleteKey = k.DELETE;
+exports.semicolonKey = k.SEMICOLON;
+exports.equalsKey = k.EQUALS;
+
+exports.numpad0Key = k.NUMPAD0;
+exports.numpad1Key = k.NUMPAD1;
+exports.numpad2Key = k.NUMPAD2;
+exports.numpad3Key = k.NUMPAD3;
+exports.numpad4Key = k.NUMPAD4;
+exports.numpad5Key = k.NUMPAD5;
+exports.numpad6Key = k.NUMPAD6;
+exports.numpad7Key = k.NUMPAD7;
+exports.numpad8Key = k.NUMPAD8;
+exports.numpad9Key = k.NUMPAD9;
+
+exports.multiplyKey = k.MULTIPLY;
+exports.addKey = k.ADD;
+exports.separatorKey = k.SEPARATOR;
+exports.subtractKey = k.SUBTRACT;
+exports.decimalKey = k.DECIMAL;
+exports.divideKey = k.DIVIDE;
+
+exports.f1Key = k.F1;
+exports.f2Key = k.F2;
+exports.f3Key = k.F3;
+exports.f4Key = k.F4;
+exports.f5Key = k.F5;
+exports.f6Key = k.F6;
+exports.f7Key = k.F7;
+exports.f8Key = k.F8;
+exports.f9Key = k.F9;
+exports.f10Key = k.F10;
+exports.f11Key = k.F11;
+exports.f12Key = k.F12;
+
 exports.commandKey = k.COMMAND;
 exports.metaKey = k.META;
+
+exports.zenkakuHanakuKey = k.ZENKAKU_HANAKU;
+

--- a/src/Selenium/Key.purs
+++ b/src/Selenium/Key.purs
@@ -1,10 +1,72 @@
-module Selenium.Key where
-
+module Selenium.Extra.Key
+  where
 import Selenium.Types
 
--- TODO: port all `Key` enum
-foreign import altKey ∷ ControlKey
-foreign import controlKey ∷ ControlKey
+foreign import nullKey ∷ ControlKey
+foreign import cancelKey ∷ ControlKey
+foreign import helpKey ∷ ControlKey
+foreign import backSpaceKey ∷ ControlKey
+foreign import tabKey ∷ ControlKey
+foreign import clearKey ∷ ControlKey
+foreign import returnKey ∷ ControlKey
+foreign import enterKey ∷ ControlKey
 foreign import shiftKey ∷ ControlKey
+foreign import controlKey ∷ ControlKey
+foreign import altKey ∷ ControlKey
+foreign import pauseKey ∷ ControlKey
+foreign import escapeKey ∷ ControlKey
+foreign import spaceKey ∷ ControlKey
+foreign import pageUpKey ∷ ControlKey
+foreign import pageDownKey ∷ ControlKey
+foreign import endKey ∷ ControlKey
+foreign import homeKey ∷ ControlKey
+foreign import arrowLeftKey ∷ ControlKey
+foreign import leftKey ∷ ControlKey
+foreign import arrowUpKey ∷ ControlKey
+foreign import upKey ∷ ControlKey
+foreign import arrowRightKey ∷ ControlKey
+foreign import rightKey ∷ ControlKey
+foreign import arrowDownKey ∷ ControlKey
+foreign import downKey ∷ ControlKey
+
+foreign import insertKey ∷ ControlKey
+foreign import deleteKey ∷ ControlKey
+foreign import semicolonKey ∷ ControlKey
+foreign import equalsKey ∷ ControlKey
+
+foreign import numpad0Key ∷ ControlKey
+foreign import numpad1Key ∷ ControlKey
+foreign import numpad2Key ∷ ControlKey
+foreign import numpad3Key ∷ ControlKey
+foreign import numpad4Key ∷ ControlKey
+foreign import numpad5Key ∷ ControlKey
+foreign import numpad6Key ∷ ControlKey
+foreign import numpad7Key ∷ ControlKey
+foreign import numpad8Key ∷ ControlKey
+foreign import numpad9Key ∷ ControlKey
+
+foreign import multiplyKey ∷ ControlKey
+foreign import addKey ∷ ControlKey
+foreign import separatorKey ∷ ControlKey
+foreign import subtractKey ∷ ControlKey
+foreign import decimalKey ∷ ControlKey
+foreign import divideKey ∷ ControlKey
+
+foreign import f1Key ∷ ControlKey
+foreign import f2Key ∷ ControlKey
+foreign import f3Key ∷ ControlKey
+foreign import f4Key ∷ ControlKey
+foreign import f5Key ∷ ControlKey
+foreign import f6Key ∷ ControlKey
+foreign import f7Key ∷ ControlKey
+foreign import f8Key ∷ ControlKey
+foreign import f9Key ∷ ControlKey
+foreign import f10Key ∷ ControlKey
+foreign import f11Key ∷ ControlKey
+foreign import f12Key ∷ ControlKey
+
 foreign import commandKey ∷ ControlKey
 foreign import metaKey ∷ ControlKey
+
+foreign import zenkakuHanakuKey ∷ ControlKey
+


### PR DESCRIPTION
This adds all the keys found in the webdriver here:
https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/lib/input.js#L53-L122

EDIT:
I guess I see now, and this should only really be used for modifier keys.
It would still be useful for me to keep these keys as constants, I'm not sure under what type.
`String` seems good enough for me.